### PR TITLE
Adjust standalone docs after theme behavior change

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,6 +1,9 @@
 CLI Reference
 =============
 
+.. toctree::
+   :hidden:
+
 .. argparse::
     :ref: data_morph.cli._generate_parser_for_docs
     :prog: data-morph

--- a/docs/custom_datasets.rst
+++ b/docs/custom_datasets.rst
@@ -1,6 +1,9 @@
 Custom Datasets
 ===============
 
+.. toctree::
+   :hidden:
+
 This tutorial provides guidance on how to move from an idea for a custom dataset to
 an input dataset for morphing.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,9 @@
 Quick Start Guide
 =================
 
+.. toctree::
+   :hidden:
+
 .. INSTALLATION
 
 Installation

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+.. toctree::
+   :hidden:
+
 0.2.0 (September 24, 2023)
 --------------------------
 


### PR DESCRIPTION
Turn off toctree on standalone pages to hide empty section navigation in left sidebar