### PR TITLE
Switch to sphinx-argparse-cli to remove docs hack

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,10 +1,11 @@
 CLI Reference
 =============
 
-.. argparse::
-    :ref: data_morph.cli._generate_parser_for_docs
+.. sphinx_argparse_cli::
+    :module: data_morph.cli
+    :func: generate_parser
     :prog: data-morph
-    :noepilog:
+    :group_title_prefix:
 
 ----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx_copybutton',
-    'sphinxarg.ext',
+    'sphinx_argparse_cli',
     'matplotlib.sphinxext.plot_directive',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ optional-dependencies.dev = [
 optional-dependencies.docs = [
   "pydata-sphinx-theme>=0.15.3",
   "sphinx>=7.2.6",
-  "sphinx-argparse>=0.4.0",
+  "sphinx-argparse-cli>=1.16.0",
   "sphinx-copybutton>=0.5.1",
 ]
 urls."Bug Tracker" = "https://github.com/stefmolin/data-morph/issues"

--- a/src/data_morph/cli.py
+++ b/src/data_morph/cli.py
@@ -2,7 +2,6 @@
 
 import argparse
 import sys
-import textwrap
 from typing import Sequence, Union
 
 from . import __version__
@@ -17,8 +16,6 @@ ARG_DEFAULTS = {
     'iterations': 100_000,
     'freeze': 0,
 }
-
-USAGE_WIDTH_FOR_DOCS = 80
 
 
 def generate_parser() -> argparse.ArgumentParser:
@@ -206,27 +203,6 @@ def generate_parser() -> argparse.ArgumentParser:
         ),
     )
 
-    return parser
-
-
-def _generate_parser_for_docs() -> argparse.ArgumentParser:
-    """
-    Generate an argument parser for the documentation only.
-
-    Returns
-    -------
-    argparse.argparse.ArgumentParser
-        Modified argument parser class for the documentation.
-    """
-    parser = generate_parser()
-    usage_text = parser.format_usage()
-    parser.format_usage = lambda: textwrap.fill(
-        usage_text.replace('                  ', ' '),
-        width=USAGE_WIDTH_FOR_DOCS,
-        subsequent_indent='\t',
-        break_on_hyphens=False,
-        break_long_words=False,
-    )
     return parser
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,12 +30,6 @@ def test_cli_version(capsys):
     assert f'data-morph {__version__}' == capsys.readouterr().out.strip()
 
 
-def test_cli_usage_wrap_for_docs():
-    """Confirm that the usage wrapping for the docs is working."""
-    usage_text = cli._generate_parser_for_docs().format_usage()
-    assert all(len(line) <= cli.USAGE_WIDTH_FOR_DOCS for line in usage_text.split('\n'))
-
-
 def test_cli_bad_shape():
     """Test that invalid target shapes raise a ValueError."""
     with pytest.raises(ValueError, match='No valid target shapes were provided.'):


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes #159 

**Describe your changes**

Switched to `sphinx-argparse-cli` and removed the hack that was necessary for the CLI reference in the docs using the `sphinx-argparse` extension.

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [X] Test cases have been modified/added to cover any code changes.
- [X] Docstrings have been modified/created for any code changes.
- [X] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/data-morph/blob/main/CONTRIBUTING.md) for more information).
