### PR TITLE
Optimize distance calculations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,6 @@ intersphinx_mapping = {
     'Pillow': ('https://pillow.readthedocs.io/en/stable/', None),
     'pytest': ('https://pytest.org/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "matplotlib>=3.3",
   "numpy>=1.20",
   "pandas>=1.2",
-  "scipy>=1.10.0",
   "tqdm>=4.64.1",
 ]
 optional-dependencies.dev = [

--- a/src/data_morph/shapes/bases/line_collection.py
+++ b/src/data_morph/shapes/bases/line_collection.py
@@ -4,6 +4,7 @@ from numbers import Number
 from typing import Iterable
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.axes import Axes
 
 from ...plotting.style import plot_with_custom_style
@@ -76,7 +77,7 @@ class LineCollection(Shape):
         .. _this VBA code: http://local.wasp.uwa.edu.au/~pbourke/geometry/pointline/source.vba
         """
         start, end = line
-        line_mag = self._euclidean_distance(start, end)
+        line_mag = self._euclidean_distance(np.array(start), np.array(end))
 
         if line_mag < 0.00000001:
             # Arbitrarily large value
@@ -93,14 +94,14 @@ class LineCollection(Shape):
             # closest point does not fall within the line segment, take the shorter
             # distance to an endpoint
             distance = min(
-                self._euclidean_distance(point, start),
-                self._euclidean_distance(point, end),
+                self._euclidean_distance(np.array(point), np.array(start)),
+                self._euclidean_distance(np.array(point), np.array(end)),
             )
         else:
             # Intersecting point is on the line, use the formula
             ix = x1 + u * (x2 - x1)
             iy = y1 + u * (y2 - y1)
-            distance = self._euclidean_distance(point, (ix, iy))
+            distance = self._euclidean_distance(np.array(point), np.array((ix, iy)))
 
         return distance
 

--- a/src/data_morph/shapes/bases/line_collection.py
+++ b/src/data_morph/shapes/bases/line_collection.py
@@ -76,8 +76,9 @@ class LineCollection(Shape):
 
         .. _this VBA code: http://local.wasp.uwa.edu.au/~pbourke/geometry/pointline/source.vba
         """
-        start, end = line
-        line_mag = self._euclidean_distance(np.array(start), np.array(end))
+        start, end = np.array(line)
+        line_mag = self._euclidean_distance(start, end)
+        point = np.array(point)
 
         if line_mag < 0.00000001:
             # Arbitrarily large value
@@ -94,14 +95,14 @@ class LineCollection(Shape):
             # closest point does not fall within the line segment, take the shorter
             # distance to an endpoint
             distance = min(
-                self._euclidean_distance(np.array(point), np.array(start)),
-                self._euclidean_distance(np.array(point), np.array(end)),
+                self._euclidean_distance(point, start),
+                self._euclidean_distance(point, end),
             )
         else:
             # Intersecting point is on the line, use the formula
             ix = x1 + u * (x2 - x1)
             iy = y1 + u * (y2 - y1)
-            distance = self._euclidean_distance(np.array(point), np.array((ix, iy)))
+            distance = self._euclidean_distance(point, np.array((ix, iy)))
 
         return distance
 

--- a/src/data_morph/shapes/bases/shape.py
+++ b/src/data_morph/shapes/bases/shape.py
@@ -67,7 +67,7 @@ class Shape(ABC):
 
         See Also
         --------
-        scipy.spatial.distance.euclidean : Euclidean distance calculation.
+        numpy.linalg.norm : Euclidean distance calculation.
         """
         return np.linalg.norm(a - b)
 

--- a/src/data_morph/shapes/bases/shape.py
+++ b/src/data_morph/shapes/bases/shape.py
@@ -4,8 +4,8 @@ from abc import ABC, abstractmethod
 from numbers import Number
 from typing import Iterable, Optional
 
+import numpy as np
 from matplotlib.axes import Axes
-from scipy.spatial import distance
 
 
 class Shape(ABC):
@@ -69,7 +69,7 @@ class Shape(ABC):
         --------
         scipy.spatial.distance.euclidean : Euclidean distance calculation.
         """
-        return distance.euclidean(a, b)
+        return np.linalg.norm(a - b)
 
     def _recursive_repr(self, attr: Optional[str] = None) -> str:
         """

--- a/src/data_morph/shapes/circles.py
+++ b/src/data_morph/shapes/circles.py
@@ -60,7 +60,10 @@ class Circle(Shape):
         float
             The absolute distance between this circle's edge and the point (x, y).
         """
-        return abs(self._euclidean_distance((self.cx, self.cy), (x, y)) - self.r)
+        return abs(
+            self._euclidean_distance(np.array([self.cx, self.cy]), np.array([x, y]))
+            - self.r
+        )
 
     @plot_with_custom_style
     def plot(self, ax: Axes = None) -> Axes:
@@ -125,6 +128,9 @@ class Rings(Shape):
         ]
         """list[Circle]: The individual rings represented by :class:`Circle` objects."""
 
+        self._coords = np.array([(circle.cx, circle.cy) for circle in self.circles])
+        self._radii = np.array([circle.r for circle in self.circles])
+
     def __repr__(self) -> str:
         return self._recursive_repr('circles')
 
@@ -150,7 +156,10 @@ class Rings(Shape):
             Rings consists of multiple circles, so we use the minimum
             distance to one of the circles.
         """
-        return min(circle.distance(x, y) for circle in self.circles)
+        point = np.array([x, y])
+        return np.min(
+            np.abs(np.linalg.norm(self._coords - point, axis=1) - self._radii)
+        )
 
     @plot_with_custom_style
     def plot(self, ax: Axes = None) -> Axes:

--- a/src/data_morph/shapes/circles.py
+++ b/src/data_morph/shapes/circles.py
@@ -43,6 +43,8 @@ class Circle(Shape):
         self.r: Number = r or dataset.df.std().mean() * 1.5
         """numbers.Number: The radius of the circle."""
 
+        self._center = np.array([self.cx, self.cy])
+
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} cx={self.cx} cy={self.cy} r={self.r}>'
 
@@ -60,10 +62,7 @@ class Circle(Shape):
         float
             The absolute distance between this circle's edge and the point (x, y).
         """
-        return abs(
-            self._euclidean_distance(np.array([self.cx, self.cy]), np.array([x, y]))
-            - self.r
-        )
+        return abs(self._euclidean_distance(self._center, np.array([x, y])) - self.r)
 
     @plot_with_custom_style
     def plot(self, ax: Axes = None) -> Axes:

--- a/src/data_morph/shapes/circles.py
+++ b/src/data_morph/shapes/circles.py
@@ -128,7 +128,7 @@ class Rings(Shape):
         ]
         """list[Circle]: The individual rings represented by :class:`Circle` objects."""
 
-        self._coords = np.array([(circle.cx, circle.cy) for circle in self.circles])
+        self._centers = np.array([(circle.cx, circle.cy) for circle in self.circles])
         self._radii = np.array([circle.r for circle in self.circles])
 
     def __repr__(self) -> str:
@@ -158,7 +158,7 @@ class Rings(Shape):
         """
         point = np.array([x, y])
         return np.min(
-            np.abs(np.linalg.norm(self._coords - point, axis=1) - self._radii)
+            np.abs(np.linalg.norm(self._centers - point, axis=1) - self._radii)
         )
 
     @plot_with_custom_style

--- a/src/data_morph/shapes/circles.py
+++ b/src/data_morph/shapes/circles.py
@@ -127,7 +127,7 @@ class Rings(Shape):
         ]
         """list[Circle]: The individual rings represented by :class:`Circle` objects."""
 
-        self._centers = np.array([(circle.cx, circle.cy) for circle in self.circles])
+        self._centers = np.array([circle._center for circle in self.circles])
         self._radii = np.array([circle.r for circle in self.circles])
 
     def __repr__(self) -> str:


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes #202

**Describe your changes**

- use `numpy.linalg.norm` instead of `scipy.spatial.distance` (see [this SO comment](https://stackoverflow.com/questions/1401712/how-can-the-euclidean-distance-be-calculated-with-numpy#comment51077024_21986532) and [this SO answer](https://stackoverflow.com/a/47775357) for performance benchmarks)
- cache all `Circle` instances when we create an instance of `Rings`, and compute all separations via numpy

I've benchmarked the above 2 on the `bullseye` and `rings` shapes, and the results are nice:

```plaintext
# bullseye on main
218292773 function calls (215844061 primitive calls) in 85.438 seconds
# bullseye w/ this PR
211510859 function calls (209069591 primitive calls) in 82.753 seconds
# rings on main
224466386 function calls (222017681 primitive calls) in 86.428 seconds
# rings w/ this PR
210318700 function calls (207877434 primitive calls) in 82.098 seconds
```

While the relative performance improvement appears marginal, it only appears that way due to Pandas-related operations being the bottleneck, and for `bullseye` we get **6.7M less** function calls, while for `rings` we get **14.1M less** function calls in total.

Note that no changes were made to the public API.

<!-- TODO -->

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [x] Test cases have been modified/added to cover any code changes.
- [x] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/data-morph/blob/main/CONTRIBUTING.md) for more information).
