### PR TITLE
Fix return type should be BoundingBox

### DIFF
--- a/src/data_morph/data/dataset.py
+++ b/src/data_morph/data/dataset.py
@@ -65,7 +65,7 @@ class Dataset:
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} name={self.name} scaled={self._scaled}>'
 
-    def _derive_data_bounds(self) -> None:
+    def _derive_data_bounds(self) -> BoundingBox:
         """
         Derive bounds based on the data.
 
@@ -81,7 +81,7 @@ class Dataset:
             ]
         )
 
-    def _derive_morphing_bounds(self) -> None:
+    def _derive_morphing_bounds(self) -> BoundingBox:
         """
         Derive morphing bounds based on the data.
 
@@ -99,7 +99,7 @@ class Dataset:
         morph_bounds.adjust_bounds(x=x_offset, y=y_offset)
         return morph_bounds
 
-    def _derive_plotting_bounds(self) -> None:
+    def _derive_plotting_bounds(self) -> BoundingBox:
         """
         Derive plotting bounds based on the morphing bounds.
 


### PR DESCRIPTION
The return type of these three methods is set to None, but it returns a BoundingBox:

* _derive_data_bounds
* _derive_morphing_bounds
* _derive_plotting_bounds

Set the correct return type to BoundingBox instead of None.

Fixes #208

- [ ] Test cases have been modified/added to cover any code changes.
- [ ] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/data-morph/blob/main/CONTRIBUTING.md) for more information).

I'm not sure if test cases are needed because this change is so small.