### PR TITLE
Add more fonts to avoid errors

### DIFF
--- a/src/data_morph/plotting/config/plot_style.mplstyle
+++ b/src/data_morph/plotting/config/plot_style.mplstyle
@@ -2,7 +2,7 @@
 font.size: 12.0
 font.family: monospace
 font.weight: normal
-font.sans-serif: Helvetica, Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Arial, Avant Garde, sans-serif
-font.monospace: Decima Mono, Bitstream Vera Sans Mono, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+font.sans-serif: Helvetica, DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Avant Garde, sans-serif
+font.monospace: Decima Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
 text.color: 222222
 pdf.fonttype: 42


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes #213

**Describe your changes**
I had the following errors on my system.

```
findfont: Generic family 'sans-serif' not found because none of the following families were found: Helvetica, Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Arial, Avant Garde, sans-serif
findfont: Generic family 'monospace' not found because none of the following families were found: Decima Mono, Bitstream Vera Sans Mono, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
```

I tried to install the fonts but I couldn't make it find it. So I ran the following commands and added the fonts it showed to the configuration file.

```
>>> import matplotlib as plt
>>> ', '.join(plt.rcParams['font.sans-serif'])
>>> ', '.join(plt.rcParams['font.monospace'])
```

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [ ] Test cases have been modified/added to cover any code changes.
- [ ] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/data-morph/blob/main/CONTRIBUTING.md) for more information).
