### PR TITLE
Remove `docs/api/` documents generated by Sphinx for `make clean`

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ help:
 .PHONY: help Makefile
 
 clean:
-	-rm -rf `dirname $(BUILDDIR)`/html/*/ $(BUILDDIR)
+	-rm -rf `dirname $(BUILDDIR)`/html/*/ $(BUILDDIR) api
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Need to clear out `docs/api/` when reviewing multiple PRs for shapes as the docs build will error out if the shape isn't present on a branch after you build the docs on another branch.