### PR TITLE
Run in parallel via CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
             os: [macos-latest, ubuntu-latest, windows-latest]
             python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
+    env:
+      MPLBACKEND: Agg  # non-interactive backend for matplotlib
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
       - name: Install testing dependencies
         run: python -m pip install '.[dev]'
 
+      - name: Set the plot backend on Windows to deal with intermittent tkinter issues
+        if: matrix.os == 'windows-latest'
+        run: set MPLBACKEND=agg
+
       - name: Run tests
         run: pytest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,6 @@ jobs:
       - name: Install testing dependencies
         run: python -m pip install '.[dev]'
 
-      - name: Set the plot backend on Windows to deal with intermittent tkinter issues
-        if: matrix.os == 'windows-latest'
-        run: set MPLBACKEND=agg
-
       - name: Run tests
         run: pytest
 

--- a/.github/workflows/generate-morphs.yml
+++ b/.github/workflows/generate-morphs.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           data-morph \
                --start-shape music \
-               --target-shape bullseye heart rectangle star slant_up \
+               --target-shape bullseye heart star \
                --workers 0
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0

--- a/.github/workflows/generate-morphs.yml
+++ b/.github/workflows/generate-morphs.yml
@@ -64,10 +64,10 @@ jobs:
           echo "Detected changes to dataset(s): $DATASET_ALL_CHANGED_FILES"
           DATASET_ARGS=$(python bin/ci.py $DATASET_ALL_CHANGED_FILES)
           echo "Generating morphs for the following datasets: $DATASET_ARGS"
-          parallel -j0 data-morph \
+          data-morph \
                --start-shape $DATASET_ARGS \
-               --target-shape {} \
-               ::: bullseye heart rectangle star slant_up
+               --target-shape bullseye heart rectangle star slant_up \
+               --workers 0
 
       # If shapes are added or modified in this PR
       - name: Generate morphs from new or changed shapes
@@ -78,20 +78,20 @@ jobs:
           echo "Detected changes to shape(s): $SHAPE_ALL_CHANGED_FILES"
           SHAPE_ARGS=$(python bin/ci.py $SHAPE_ALL_CHANGED_FILES)
           echo "Generating morphs for the following shapes: $SHAPE_ARGS"
-          parallel -j0 data-morph \
+          data-morph \
                --start-shape music \
-               --target-shape {} \
-               ::: $SHAPE_ARGS
+               --target-shape $SHAPE_ARGS \
+               --workers 0
 
       # For core code changes, we want to do a couple morphs to see if they still look ok
       # Only need to run if neither of the previous two morphs ran
       - name: Morph shapes with core code changes
         if: steps.changed-files-yaml.outputs.dataset_any_changed != 'true' && steps.changed-files-yaml.outputs.shape_any_changed != 'true'
         run: |
-          parallel -j0 data-morph \
+          data-morph \
                --start-shape music \
-               --target-shape {} \
-               ::: bullseye heart rectangle star slant_up
+               --target-shape bullseye heart rectangle star slant_up \
+               --workers 0
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
         with:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,7 @@ API
    data_morph.data
    data_morph.morpher
    data_morph.plotting
+   data_morph.progress
    data_morph.shapes
 
 ----

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,11 +19,12 @@ Examples
 
     $ data-morph --start-shape panda --target-shape star
 
-2. Morph the panda shape into all available target shapes:
+2. Morph the panda shape into all available target shapes distributing the work
+   to as many worker processes as possible:
 
    .. code-block:: console
 
-    $ data-morph --start-shape panda --target-shape all
+    $ data-morph --start-shape panda --target-shape all --workers 0
 
 3. Morph the cat, dog, and panda shapes into the circle and slant_down shapes:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,12 +59,13 @@ autosectionlabel_prefix_document = True
 # -- intersphinx -------------------------------------------------------------
 
 intersphinx_mapping = {
-    'matplotlib': ('https://matplotlib.org/stable/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'Pillow': ('https://pillow.readthedocs.io/en/stable/', None),
-    'pytest': ('https://pytest.org/en/stable/', None),
-    'python': ('https://docs.python.org/3/', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
+    'Pillow': ('https://pillow.readthedocs.io/en/stable', None),
+    'pytest': ('https://pytest.org/en/stable', None),
+    'python': ('https://docs.python.org/3', None),
+    'rich': ('https://rich.readthedocs.io/en/stable', None),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ optional-dependencies.dev = [
   "pytest-cov",
   "pytest-mock",
   "pytest-randomly",
+  "pytest-xdist",
 ]
 optional-dependencies.docs = [
   "pydata-sphinx-theme>=0.15.3",
@@ -140,6 +141,7 @@ addopts = [
   "-ra",
   "-l",
   "-v",
+  "-n=auto",                   # use as many workers as possible with pytest-xdist
   "--tb=short",
   "--import-mode=importlib",
   "--strict-markers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "matplotlib>=3.3",
   "numpy>=1.20",
   "pandas>=1.2",
-  "tqdm>=4.64.1",
+  "rich>=13.9.4",
 ]
 optional-dependencies.dev = [
   "pre-commit",

--- a/src/data_morph/cli.py
+++ b/src/data_morph/cli.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import sys
+import itertools
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
+
+from rich import progress
 
 from . import __version__
 from .data.loader import DataLoader
@@ -20,6 +24,7 @@ ARG_DEFAULTS = {
     'min_shake': 0.3,
     'iterations': 100_000,
     'freeze': 0,
+    'workers': 2,
 }
 
 
@@ -49,6 +54,16 @@ def generate_parser() -> argparse.ArgumentParser:
 
     parser.add_argument(
         '--version', action='version', version=f'%(prog)s {__version__}'
+    )
+    parser.add_argument(
+        '-w',
+        '--workers',
+        type=int,
+        default=ARG_DEFAULTS['workers'],
+        help=(
+            f'The number of workers. Default {ARG_DEFAULTS["workers"]}. '
+            'Pass 0 to use as many as possible.'
+        ),
     )
 
     shape_config_group = parser.add_argument_group(
@@ -226,6 +241,34 @@ def generate_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def morph(dataset, shape, args, progress, task_id):
+    progress[task_id] = {'progress': 0, 'total': args.iterations}
+    # dataset = DataLoader.load_dataset(data, scale=args.scale)
+
+    morpher = DataMorpher(
+        decimals=args.decimals,
+        output_dir=args.output_dir,
+        write_data=args.write_data,
+        seed=args.seed,
+        keep_frames=args.keep_frames,
+        forward_only_animation=args.forward_only,
+        num_frames=100,
+        in_notebook=False,
+    )
+
+    _ = morpher.morph(
+        start_shape=dataset,
+        target_shape=shape,
+        iterations=args.iterations,
+        min_shake=args.shake,
+        ease_in=args.ease_in or args.ease,
+        ease_out=args.ease_out or args.ease,
+        freeze_for=args.freeze,
+        progress=progress,
+        task_id=task_id,
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     """
     Run Data Morph as a script.
@@ -250,32 +293,85 @@ def main(argv: Sequence[str] | None = None) -> None:
             f"""'{"', '".join(ShapeFactory.AVAILABLE_SHAPES)}'."""
         )
 
-    for start_shape in args.start_shape:
-        dataset = DataLoader.load_dataset(start_shape, scale=args.scale)
-        print(f"Processing starter shape '{dataset.name}'", file=sys.stderr)
+    datasets = {}
+    shapes = {}
+    for data in args.start_shape:
+        if data not in datasets:
+            dataset = DataLoader.load_dataset(data, scale=args.scale)
+            datasets[data] = dataset
+            factory = ShapeFactory(dataset)
+            for shape in target_shapes:
+                shapes[(data, shape)] = factory.generate_shape(shape)
 
-        shape_factory = ShapeFactory(dataset)
-        morpher = DataMorpher(
-            decimals=args.decimals,
-            output_dir=args.output_dir,
-            write_data=args.write_data,
-            seed=args.seed,
-            keep_frames=args.keep_frames,
-            forward_only_animation=args.forward_only,
-            num_frames=100,
-            in_notebook=False,
+    morphs = list(itertools.product(args.start_shape, target_shapes))
+    total_jobs = len(morphs)
+
+    max_workers = multiprocessing.cpu_count()
+    workers = max_workers if not args.workers else min(args.workers, max_workers)
+    only_show_running = total_jobs > workers
+
+    futures = []
+    with (
+        progress.Progress(
+            '[progress.description]{task.description}',
+            progress.BarColumn(),
+            '[progress.percentage]{task.percentage:>3.0f}%',
+            progress.MofNCompleteColumn(),
+            progress.TimeElapsedColumn(),
+        ) as progress_tracker,
+        multiprocessing.Manager() as manager,
+    ):
+        # this is the key - we share some state between our
+        # main process and our worker functions
+        _progress = manager.dict()
+        overall_progress_task = progress_tracker.add_task(
+            '[green]Overall progress', visible=total_jobs > 1
         )
 
-        total_shapes = len(target_shapes)
-        for i, target_shape in enumerate(target_shapes, start=1):
-            if total_shapes > 1:
-                print(f'Morphing shape {i} of {total_shapes}', file=sys.stderr)
-            _ = morpher.morph(
-                start_shape=dataset,
-                target_shape=shape_factory.generate_shape(target_shape),
-                iterations=args.iterations,
-                min_shake=args.shake,
-                ease_in=args.ease_in or args.ease,
-                ease_out=args.ease_out or args.ease,
-                freeze_for=args.freeze,
-            )
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            for dataset, shape in morphs:
+                task_id = progress_tracker.add_task(
+                    f'{dataset} to {shape}',
+                    visible=False,
+                    start=False,
+                )
+                futures.append(
+                    executor.submit(
+                        morph,
+                        datasets[dataset],
+                        shapes[(dataset, shape)],
+                        args,
+                        _progress,
+                        task_id,
+                    )
+                )
+
+            while True:
+                finished_jobs = sum(future.done() for future in futures)
+                progress_tracker.update(
+                    overall_progress_task,
+                    completed=sum(task['progress'] for task in _progress.values()),
+                    total=total_jobs * args.iterations,
+                )
+                for task_id, update_data in _progress.items():
+                    latest = update_data['progress']
+                    total = update_data['total']
+
+                    if not latest:
+                        # hack to make the elapsed time accurate for ones that start later on
+                        # this is necessary because Progress is not pickleable
+                        progress_tracker.start_task(task_id)
+
+                    progress_tracker.update(
+                        task_id,
+                        completed=latest,
+                        total=total,
+                        visible=latest < total
+                        if only_show_running
+                        else latest <= total,
+                    )
+                if finished_jobs == total_jobs:
+                    break
+
+            for future in futures:
+                future.result()

--- a/src/data_morph/cli.py
+++ b/src/data_morph/cli.py
@@ -256,7 +256,7 @@ def _morph(
     Parameters
     ----------
     data : str
-        The dataset to use. This can be the name of a built-in dataset, or a path to a
+        The dataset to use. This can be the name of a built-in dataset or a path to a
         CSV file containing the data.
     shape : str
         The name of the target shape.
@@ -265,7 +265,7 @@ def _morph(
     progress : multiprocessing.DictProxy
         The state of all task progresses.
     task_id : TaskID
-        The task ID assigned from the progress tracker.
+        The task ID assigned by the progress tracker.
 
     Notes
     -----

--- a/src/data_morph/morpher.py
+++ b/src/data_morph/morpher.py
@@ -355,8 +355,8 @@ class DataMorpher:
         ease_in: bool = False,
         ease_out: bool = False,
         freeze_for: int = 0,
-        progress: multiprocessing.DictProxy | None = None,  # TODO: docstring
-        task_id: TaskID | None = None,  # TODO: docstring
+        progress: multiprocessing.DictProxy | None = None,
+        task_id: TaskID | None = None,
     ) -> pd.DataFrame:
         """
         Morph a dataset into a target shape by perturbing it
@@ -393,7 +393,11 @@ class DataMorpher:
         freeze_for : int, default ``0``
             The number of frames to freeze at the beginning and end.
             This only affects the frames, not the algorithm. Must be in the
-            interval [0, 50].
+            interval ``[0, 50]``.
+        progress : multiprocessing.DictProxy | ``None``, optional
+            The state of all task progresses when parallelizing work (for use by the CLI).
+        task_id : TaskID | ``None``, optional
+            The task ID assigned from the progress tracker (for use by the CLI).
 
         Returns
         -------

--- a/src/data_morph/morpher.py
+++ b/src/data_morph/morpher.py
@@ -397,7 +397,7 @@ class DataMorpher:
         progress : multiprocessing.DictProxy | ``None``, optional
             The state of all task progresses when parallelizing work (for use by the CLI).
         task_id : TaskID | ``None``, optional
-            The task ID assigned from the progress tracker (for use by the CLI).
+            The task ID assigned by the progress tracker (for use by the CLI).
 
         Returns
         -------

--- a/src/data_morph/progress.py
+++ b/src/data_morph/progress.py
@@ -1,0 +1,35 @@
+"""Progress bar using rich."""
+
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TimeElapsedColumn
+
+
+class DataMorphProgress(Progress):
+    """
+    Progress tracker for Data Morph.
+
+    .. note::
+        Both the Python interface and CLI provide progress tracking using this class
+        automatically. It is unlikely you will need to use this class yourself.
+
+    Parameters
+    ----------
+    auto_refresh : bool, default ``True``
+        Whether to automatically refresh the progress bar. This should be set to ``False``
+        for Jupyter Notebooks per the `Rich progress documentation
+        <https://rich.readthedocs.io/en/stable/progress.html>`_.
+
+    See Also
+    --------
+    rich.progress.Progress
+        The base class from which all progress bar functionality derives.
+    """
+
+    def __init__(self, auto_refresh: bool = True) -> None:
+        super().__init__(
+            '[progress.description]{task.description}',
+            BarColumn(),
+            '[progress.percentage]{task.percentage:>3.0f}%',
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            auto_refresh=auto_refresh,
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,7 @@ def test_cli_bad_input_boolean(field, value, capsys):
     )
 
 
+@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize(
     ('start_shape', 'scale'),
     [('dino', 10), ('dino', 0.5), ('dino', None)],
@@ -114,6 +115,7 @@ def test_cli_dataloader(start_shape, scale, mocker):
     load.assert_called_once_with(start_shape, scale=scale)
 
 
+@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize('flag', [True, False])
 def test_cli_one_shape(start_shape, flag, mocker, tmp_path):
     """Check that the proper values are passed to morph a single shape."""
@@ -182,6 +184,7 @@ def test_cli_one_shape(start_shape, flag, mocker, tmp_path):
             assert value == morph_args[arg]
 
 
+@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize(
     ('target_shape', 'patched_options'),
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Test the CLI."""
 
+import itertools
 from pathlib import Path
 
 import pytest
@@ -94,7 +95,6 @@ def test_cli_bad_input_boolean(field, value, capsys):
     )
 
 
-@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize(
     ('start_shape', 'scale'),
     [('dino', 10), ('dino', 0.5), ('dino', None)],
@@ -115,7 +115,6 @@ def test_cli_dataloader(start_shape, scale, mocker):
     load.assert_called_once_with(start_shape, scale=scale)
 
 
-@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize('flag', [True, False])
 def test_cli_one_shape(start_shape, flag, mocker, tmp_path):
     """Check that the proper values are passed to morph a single shape."""
@@ -184,7 +183,6 @@ def test_cli_one_shape(start_shape, flag, mocker, tmp_path):
             assert value == morph_args[arg]
 
 
-@pytest.mark.skip('Need to rework for multiprocessing')
 @pytest.mark.parametrize(
     ('target_shape', 'patched_options'),
     [
@@ -196,17 +194,14 @@ def test_cli_one_shape(start_shape, flag, mocker, tmp_path):
 @pytest.mark.parametrize(
     'start_shape',
     [
-        ['dino'],
-        ['dino', 'sheep'],
-        ['dino.csv', 'sheep'],
+        ['dino.csv'],
         ['dino', 'sheep.csv'],
-        ['dino.csv', 'sheep.csv'],
     ],
-    indirect=True,
+    indirect=True,  # uses the start_shape fixture above to complete the CSV path if necessary
     ids=str,
 )
 def test_cli_multiple_shapes(
-    start_shape, target_shape, patched_options, monkeypatch, mocker, capsys
+    start_shape, target_shape, patched_options, monkeypatch, tmp_path, capsys
 ):
     """Check that multiple morphing is working."""
 
@@ -219,21 +214,33 @@ def test_cli_multiple_shapes(
 
     shapes = patched_options or target_shape
 
-    morph_noop = mocker.patch.object(cli.DataMorpher, 'morph', autospec=True)
-    cli.main(['--start-shape', *start_shape, '--target-shape', *target_shape])
-    assert morph_noop.call_count == len(shapes) * len(start_shape)
-
-    err = capsys.readouterr().err
-    assert (
-        ''.join(
-            [f'Morphing shape {i + 1} of {len(shapes)}\n' for i in range(len(shapes))]
-        )
-        in err
+    iterations = 1
+    workers = 2
+    cli.main(
+        [
+            '--start-shape',
+            *start_shape,
+            '--target-shape',
+            *target_shape,
+            f'--iterations={iterations}',
+            f'--output-dir={tmp_path}',
+            f'--workers={workers}',
+        ]
     )
-    for shape in start_shape:
-        assert Path(shape).stem in err
 
-    patterns_run = [
-        str(kwargs['target_shape']) for _, kwargs in morph_noop.call_args_list
-    ]
-    assert set(shapes).difference(patterns_run) == set()
+    total_morphs = len(shapes) * len(start_shape)
+
+    out = capsys.readouterr().out
+    total_iterations = total_morphs * iterations
+    assert 'Overall progress' in out
+    assert f'100% {total_iterations}/{total_iterations}'
+
+    if workers >= total_morphs:
+        for shape in start_shape:
+            assert Path(shape).stem in out
+    else:
+        # only the overall progress should show up in this case
+        assert len(out.splitlines()) == 1
+
+    for dataset, shape in itertools.product(start_shape, shapes):
+        assert (tmp_path / f'{Path(dataset).stem}_to_{shape}.gif').exists()

--- a/tests/test_morpher.py
+++ b/tests/test_morpher.py
@@ -175,9 +175,9 @@ class TestDataMorpher:
             assert_frame_equal(morphed_data, dataset.data)
         assert morpher._is_close_enough(dataset.data, morphed_data)
 
-        _, err = capsys.readouterr()
-        assert f'{target_shape} pattern: 100%' in err
-        assert f' {iterations}/{iterations} ' in err
+        out, _ = capsys.readouterr()
+        assert f'{dataset.name} to {target_shape}' in out
+        assert f' {iterations}/{iterations} ' in out
 
     def test_saving_data(self, tmp_path):
         """Test that writing files to disk in the morph() method is working."""


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes #218
Fixes #274 (hopefully)

**Describe your changes**

- Switch from `tqdm` to `rich` for progress tracking
- Set up `pytest-xdist` to distribute tests over multiple CPU cores
- Reworked CLI to parallelize morphing over specified number of workers when there is more than one job and more than one worker requested. Passing `0` will use all available cores.
- Updated docs and test suite for new additions
- Set matplotlib backend to Agg in actions to hopefully fix tkinter issue on Windows runners

<img width="698" alt="Screenshot 2025-02-16 at 12 38 07 PM" src="https://github.com/user-attachments/assets/3b21786a-cfe9-42a5-baa8-44932a6cfdea" />

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [x] Test cases have been modified/added to cover any code changes.
- [x] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/data-morph/blob/main/CONTRIBUTING.md) for more information).
