### PR TITLE
Save only unique frames and use GIF frame durations from PIL

### DIFF
--- a/src/data_morph/morpher.py
+++ b/src/data_morph/morpher.py
@@ -215,25 +215,22 @@ class DataMorpher:
         frame_number : str
             The frame number with padding zeros added already.
         """
-        if self.write_images or self.write_data:
-            is_start = int(frame_number) == 0
-            if self.write_images:
-                plot(
-                    data,
-                    save_to=self.output_dir
-                    / f'{base_file_name}-image-{frame_number}.png',
-                    decimals=self.decimals,
-                    x_bounds=bounds.x_bounds,
-                    y_bounds=bounds.y_bounds,
-                    dpi=150,
-                )
-            if (
-                self.write_data and not is_start
-            ):  # don't write data for the initial frame (input data)
-                data.to_csv(
-                    self.output_dir / f'{base_file_name}-data-{frame_number}.csv',
-                    index=False,
-                )
+        if self.write_images:
+            plot(
+                data,
+                save_to=self.output_dir / f'{base_file_name}-image-{frame_number}.png',
+                decimals=self.decimals,
+                x_bounds=bounds.x_bounds,
+                y_bounds=bounds.y_bounds,
+                dpi=150,
+            )
+        if (
+            self.write_data and int(frame_number) > 0
+        ):  # don't write data for the initial frame (input data)
+            data.to_csv(
+                self.output_dir / f'{base_file_name}-data-{frame_number}.csv',
+                index=False,
+            )
 
     def _is_close_enough(self, df1: pd.DataFrame, df2: pd.DataFrame) -> bool:
         """

--- a/src/data_morph/morpher.py
+++ b/src/data_morph/morpher.py
@@ -200,7 +200,7 @@ class DataMorpher:
         bounds: BoundingBox,
         base_file_name: str,
         frame_number: str,
-    ) -> int:
+    ) -> None:
         """
         Record frame data as a plot and, when :attr:`write_data` is ``True``, as a CSV file.
 

--- a/tests/plotting/test_animation.py
+++ b/tests/plotting/test_animation.py
@@ -60,10 +60,11 @@ def test_frame_stitching(sample_data, tmp_path, forward_only):
                     2 if not forward_only and frame == len(frame_numbers) - 1 else 1
                 )
                 # duration only seems to be present on frames where it is different
-                assert (
-                    img.info['duration']
-                    == duration_multipliers.count(frame) * 5 * rewind_multiplier
-                )
+                if frame_duration := img.info['duration']:
+                    assert (
+                        frame_duration
+                        == duration_multipliers.count(frame) * 5 * rewind_multiplier
+                    )
             with suppress(EOFError):
                 # move to the next frame
                 img.seek(img.tell() + 1)


### PR DESCRIPTION
- Rather than creating an image for each frame, create one only for unique frames and then use PIL to set the duration for each frame when stitching together the GIF
- Refactored `DataMorpher._record_frames()` to just record and not advance the frame number
- Changed frame numbers in file names to iteration numbers
- Add `frame_numbers` parameter to `stitch_gif_animation()` for calculating durations
- Improve testing of `stitch_gif_animation()` to count frames and durations

Benefits:
- Significant reduction in file size of resulting GIF (~0.6 MB)
- Under one minute when just running a single job (music to heart in 53 seconds)
- ~10 second improvement per job from #273 
  - The majority of which was the time it took for the progress bars to start showing progress &rarr; this was the time it took for the initial frames to be created before the morphing could even start
  - Progress also starts right away now

<img width="812" alt="Screenshot 2025-02-16 at 7 27 44 PM" src="https://github.com/user-attachments/assets/98f524cc-1e47-4f3c-8071-88726585bf72" />
