### PR TITLE
Switch license badge to one that reads from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
         <img alt="Supported Python Versions" src="https://img.shields.io/pypi/pyversions/data-morph-ai">
       </a>
       <a href="https://github.com/stefmolin/data-morph/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">
-         <img alt="License" src="https://img.shields.io/pypi/l/data-morph-ai.svg?color=blueviolet">
+         <img alt="License" src="https://img.shields.io/github/license/stefmolin/data-morph?color=blueviolet">
       </a>
      </td>
    </tr>


### PR DESCRIPTION
After the changes to the metadata necessary for publishing with setuptools, it looks like the old badge isn't finding the license on PyPI (despite it being on there). This PR switches it to use license file from GitHub.