### PR TITLE
Add marginal plots with option to revert to classic plot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         fail-fast: false
         matrix:
             os: [macos-latest, ubuntu-latest, windows-latest]
-            python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     env:
       MPLBACKEND: Agg  # non-interactive backend for matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dynamic = [
 
 dependencies = [
   "matplotlib>=3.10",
-  "numpy>=1.20",
-  "pandas>=1.2",
+  "numpy>=1.23.0",
+  "pandas>=2.1",
   "rich>=13.9.4",
 ]
 optional-dependencies.dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ authors = [
   { name = "Aaron Stevens", email = "bheklilr2@gmail.com" },
   { name = "Justin Matejka", email = "Justin.Matejka@Autodesk.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Framework :: Matplotlib",
   "Intended Audience :: Education",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -44,7 +43,7 @@ dynamic = [
 ]
 
 dependencies = [
-  "matplotlib>=3.7",
+  "matplotlib>=3.10",
   "numpy>=1.20",
   "pandas>=1.2",
   "rich>=13.9.4",

--- a/src/data_morph/__init__.py
+++ b/src/data_morph/__init__.py
@@ -28,5 +28,5 @@ Read more about the creation of Data Morph in `this article
 and `this slide deck <https://stefaniemolin.com/data-morph-talk/#/>`_.
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.0.dev0'
 MAIN_DIR = __name__

--- a/src/data_morph/data/dataset.py
+++ b/src/data_morph/data/dataset.py
@@ -6,6 +6,7 @@ from numbers import Number
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
+import numpy as np
 
 from ..bounds.bounding_box import BoundingBox
 from ..bounds.interval import Interval
@@ -68,6 +69,13 @@ class Dataset:
 
         self.plot_bounds: BoundingBox = self._derive_plotting_bounds()
         """BoundingBox: The bounds to use when plotting the morphed data."""
+
+        self.x_marginal: tuple[np.ndarray, np.ndarray] = np.histogram(
+            self.data.x, bins=30, range=self.plot_bounds.x_bounds
+        )
+        self.y_marginal: tuple[np.ndarray, np.ndarray] = np.histogram(
+            self.data.y, bins=30, range=self.plot_bounds.y_bounds
+        )
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} name={self.name} scaled={self._scaled}>'

--- a/src/data_morph/morpher.py
+++ b/src/data_morph/morpher.py
@@ -198,6 +198,8 @@ class DataMorpher:
         self,
         data: pd.DataFrame,
         bounds: BoundingBox,
+        x_marginal,
+        y_marginal,
         base_file_name: str,
         frame_number: str,
     ) -> None:
@@ -222,6 +224,8 @@ class DataMorpher:
                 decimals=self.decimals,
                 x_bounds=bounds.x_bounds,
                 y_bounds=bounds.y_bounds,
+                x_marginal=x_marginal,
+                y_marginal=y_marginal,
                 dpi=150,
             )
         if (
@@ -442,6 +446,8 @@ class DataMorpher:
         base_file_name = f'{start_shape.name}-to-{target_shape}'
         record_frames = partial(
             self._record_frames,
+            x_marginal=start_shape.x_marginal,
+            y_marginal=start_shape.y_marginal,
             base_file_name=base_file_name,
             bounds=start_shape.plot_bounds,
         )

--- a/src/data_morph/plotting/static.py
+++ b/src/data_morph/plotting/static.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import EngFormatter
+from matplotlib.ticker import EngFormatter, MaxNLocator
 
 from ..data.stats import get_summary_statistics
 from .style import plot_with_custom_style
@@ -26,6 +26,8 @@ def plot(
     data: pd.DataFrame,
     x_bounds: Iterable[Number],
     y_bounds: Iterable[Number],
+    x_marginal,
+    y_marginal,
     save_to: str | Path,
     decimals: int,
     **save_kwds: Any,  # noqa: ANN401
@@ -53,21 +55,48 @@ def plot(
         When ``save_to`` is falsey, an :class:`~matplotlib.axes.Axes` object is returned.
     """
     fig, ax = plt.subplots(
-        figsize=(7, 3), layout='constrained', subplot_kw={'aspect': 'equal'}
+        figsize=(9, 3), layout='constrained', subplot_kw={'aspect': 'equal'}
     )
     fig.get_layout_engine().set(w_pad=1.4, h_pad=0.2, wspace=0)
 
     ax.scatter(data.x, data.y, s=1, alpha=0.7, color='black')
     ax.set(xlim=x_bounds, ylim=y_bounds)
 
+    ax_histx = ax.inset_axes([0, 1.05, 1, 0.25], sharex=ax)
+    ax_histy = ax.inset_axes([1.05, 0, 0.25, 1], sharey=ax)
+
+    x_marginal_counts, x_marginal_bins = x_marginal
+    y_marginal_counts, y_marginal_bins = y_marginal
+
+    ax_histx.set(xlim=x_bounds, ylim=(0, np.ceil(x_marginal_counts.max() * 2)))
+    ax_histy.set(xlim=(0, np.ceil(y_marginal_counts.max() * 2)), ylim=y_bounds)
+
+    # no labels on marginal axis that shares with scatter plot
+    ax_histx.tick_params(axis='x', labelbottom=False)
+    ax_histy.tick_params(axis='y', labelleft=False)
+
+    # move marginal axis ticks that are visible to the corner and only show the non-zero label
+    locator = MaxNLocator(2, integer=True, prune='lower')
+    ax_histx.tick_params(axis='y', labelleft=False, labelright=True)
+    ax_histx.yaxis.set_major_locator(locator)
+    ax_histy.tick_params(axis='x', labelbottom=False, labeltop=True)
+    ax_histy.xaxis.set_major_locator(locator)
+
+    ax_histx.hist(data.x, bins=x_marginal_bins, color='gray', ec='black')
+    ax_histy.hist(
+        data.y, bins=y_marginal_bins, orientation='horizontal', color='gray', ec='black'
+    )
+
     tick_formatter = EngFormatter()
     ax.xaxis.set_major_formatter(tick_formatter)
+    ax_histy.xaxis.set_major_formatter(tick_formatter)
     ax.yaxis.set_major_formatter(tick_formatter)
+    ax_histx.yaxis.set_major_formatter(tick_formatter)
 
     res = get_summary_statistics(data)
 
     labels = ('X Mean', 'Y Mean', 'X SD', 'Y SD', 'Corr.')
-    locs = np.linspace(0.8, 0.2, num=len(labels))
+    locs = np.linspace(1.15, 0.1, num=len(labels))
     max_label_length = max([len(label) for label in labels])
     max_stat = int(np.log10(np.max(np.abs(res)))) + 1
     mean_x_digits, mean_y_digits = (
@@ -90,17 +119,19 @@ def plot(
 
     add_stat_text = partial(
         ax.text,
-        1.05,
+        1.4,
         fontsize=15,
         transform=ax.transAxes,
         va='center',
     )
-    for label, loc, stat in zip(labels[:-1], locs, res):
+    for label, loc, stat in zip(labels[:-1], locs, res, strict=False):
         add_stat_text(loc, formatter(label, stat), alpha=0.3)
         add_stat_text(loc, formatter(label, stat)[:-stat_clip])
 
     correlation_str = corr_formatter(labels[-1], res.correlation)
-    for alpha, text in zip([0.3, 1], [correlation_str, correlation_str[:-stat_clip]]):
+    for alpha, text in zip(
+        [0.3, 1], [correlation_str, correlation_str[:-stat_clip]], strict=False
+    ):
         add_stat_text(
             locs[-1],
             text,

--- a/tests/plotting/test_animation.py
+++ b/tests/plotting/test_animation.py
@@ -30,6 +30,7 @@ def test_frame_stitching(sample_data, tmp_path, forward_only):
             save_to=(tmp_path / f'{start_shape}-to-{target_shape}-{frame}.png'),
             decimals=2,
             with_median=False,
+            marginals=None,
         )
 
     duration_multipliers = [0, 0, 0, 0, 1, 1, *frame_numbers[2:], frame_numbers[-1]]

--- a/tests/plotting/test_static.py
+++ b/tests/plotting/test_static.py
@@ -1,5 +1,7 @@
 """Test the static module."""
 
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 from data_morph.plotting.static import plot
@@ -8,16 +10,23 @@ pytestmark = pytest.mark.plotting
 
 
 @pytest.mark.parametrize(
-    ('file_path', 'with_median'),
+    ('file_path', 'with_median', 'classic'),
     [
-        ('test_plot.png', False),
-        (None, True),
-        (None, False),
+        ('test_plot.png', False, True),
+        (None, True, True),
+        (None, False, True),
+        (None, True, False),
+        (None, False, False),
     ],
 )
-def test_plot(sample_data, tmp_path, file_path, with_median):
+def test_plot(sample_data, tmp_path, file_path, with_median, classic):
     """Test static plot creation."""
     bounds = (-5.0, 105.0)
+
+    marginals = (
+        None if classic else (np.histogram(sample_data.x), np.histogram(sample_data.y))
+    )
+
     if file_path:
         save_to = tmp_path / 'another-level' / file_path
 
@@ -28,6 +37,7 @@ def test_plot(sample_data, tmp_path, file_path, with_median):
             save_to=save_to,
             decimals=2,
             with_median=with_median,
+            marginals=marginals,
         )
         assert save_to.is_file()
 
@@ -39,6 +49,7 @@ def test_plot(sample_data, tmp_path, file_path, with_median):
             save_to=None,
             decimals=2,
             with_median=with_median,
+            marginals=marginals,
         )
 
         # confirm that the stylesheet was used
@@ -52,3 +63,10 @@ def test_plot(sample_data, tmp_path, file_path, with_median):
         expected_stats = 7 if with_median else 5
         expected_texts = 2 * expected_stats  # label and the number
         assert len(ax.texts) == expected_texts
+
+        # if marginals should be there, check for two inset Axes
+        expected_insets = 0 if classic else 2
+        inset_axes = [
+            child for child in ax.get_children() if isinstance(child, plt.Axes)
+        ]
+        assert len(inset_axes) == expected_insets

--- a/tests/test_morpher.py
+++ b/tests/test_morpher.py
@@ -263,8 +263,9 @@ class TestDataMorpher:
         morpher._record_frames(
             dataset.data,
             dataset.plot_bounds,
-            base_path,
-            frame_number,
+            marginals=None,
+            base_file_name=base_path,
+            frame_number=frame_number,
         )
 
         images = list(tmp_path.glob(f'{base_path}*.png'))


### PR DESCRIPTION
- Add marginal plots to default plotting settings
- Original plot is available by passing `--classic` to the CLI or `classic=True` to the `DataMorpher`
- Increased the minimum Python version to 3.10
- Increased the minimum Matplotlib version to 3.10
- Increased the minimum NumPy version to 1.23.0
- Increased the minimum pandas version to 2.1